### PR TITLE
Empty bin directory

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,3 @@
+# Keep this directory empty
+*
+!.gitignore


### PR DESCRIPTION
 Contains a .gitignore to prevent build products from being committed accidentally.

Fixes #7.